### PR TITLE
Add no-vote extend option

### DIFF
--- a/addons/sourcemod/scripting/mapchooser_extended.sp
+++ b/addons/sourcemod/scripting/mapchooser_extended.sp
@@ -231,9 +231,9 @@ public void OnPluginStart()
 	g_Cvar_StartTime = CreateConVar("mce_starttime", "10.0", "Specifies when to start the vote based on time remaining.", _, true, 1.0);
 	g_Cvar_StartRounds = CreateConVar("mce_startround", "2.0", "Specifies when to start the vote based on rounds remaining. Use 0 on DoD:S, CS:S, and TF2 to start vote during bonus round time", _, true, 0.0);
 	g_Cvar_StartFrags = CreateConVar("mce_startfrags", "5.0", "Specifies when to start the vote base on frags remaining.", _, true, 1.0);
-	g_Cvar_ExtendTimeStep = CreateConVar("mce_extend_timestep", "15", "Specifies how much many more minutes each extension makes", _, true, 5.0);
-	g_Cvar_ExtendRoundStep = CreateConVar("mce_extend_roundstep", "5", "Specifies how many more rounds each extension makes", _, true, 1.0);
-	g_Cvar_ExtendFragStep = CreateConVar("mce_extend_fragstep", "10", "Specifies how many more frags are allowed when map is extended.", _, true, 5.0);	
+	g_Cvar_ExtendTimeStep = CreateConVar("mce_extend_timestep", "15", "Specifies how much many more minutes each extension makes", _, true, 1.0);
+	g_Cvar_ExtendRoundStep = CreateConVar("mce_extend_roundstep", "5", "Specifies how many more rounds each extension makes", _, true);
+	g_Cvar_ExtendFragStep = CreateConVar("mce_extend_fragstep", "10", "Specifies how many more frags are allowed when map is extended.", _, true);	
 	g_Cvar_ExcludeMaps = CreateConVar("mce_exclude", "5", "Specifies how many past maps to exclude from the vote.", _, true, 0.0);
 	g_Cvar_IncludeMaps = CreateConVar("mce_include", "5", "Specifies how many maps to include in the vote.", _, true, 2.0, true, 6.0);
 	g_Cvar_NoVoteMode = CreateConVar("mce_novote", "1", "Specifies if MapChooser should pick a map (1), extend (2), or do nothing (0) if no votes are received.", _, true, 0.0, true, 2.0);

--- a/addons/sourcemod/scripting/mapchooser_extended.sp
+++ b/addons/sourcemod/scripting/mapchooser_extended.sp
@@ -1228,52 +1228,9 @@ public void Handler_VoteFinishedGeneric(Handle menu, int num_votes, int num_clie
 
 	if (strcmp(map, VOTE_EXTEND, false) == 0)
 	{
-		g_Extends++;
-		
-		int time;
-		if (GetMapTimeLimit(time))
-		{
-			if (time > 0)
-			{
-				ExtendMapTimeLimit(g_Cvar_ExtendTimeStep.IntValue * 60);
-			}
-		}
-		
-		if (g_Cvar_Winlimit)
-		{
-			int winlimit = g_Cvar_Winlimit.IntValue;
-			if (winlimit)
-			{
-				g_Cvar_Winlimit.IntValue = winlimit + g_Cvar_ExtendRoundStep.IntValue;
-			}
-		}
-		
-		if (g_Cvar_Maxrounds)
-		{
-			int maxrounds = g_Cvar_Maxrounds.IntValue;
-			if (maxrounds)
-			{
-				g_Cvar_Maxrounds.IntValue = maxrounds + g_Cvar_ExtendRoundStep.IntValue;
-			}
-		}
-		
-		if (g_Cvar_Fraglimit)
-		{
-			int fraglimit = g_Cvar_Fraglimit.IntValue;
-			if (fraglimit)
-			{
-				g_Cvar_Fraglimit.IntValue = fraglimit + g_Cvar_ExtendFragStep.IntValue;
-			}
-		}
-
+		ExtendMap();
 		CPrintToChatAll("%s%t", g_szChatPrefix, "Current Map Extended", RoundToFloor(float(item_info[0][VOTEINFO_ITEM_VOTES])/float(num_votes)*100), num_votes);
 		LogAction(-1, -1, "Voting for next map has finished. The current map has been extended.");
-		
-		// We extended, so we'll have to vote again.
-		g_HasVoteStarted = false;
-		CreateNextVote();
-		SetupTimeleftTimer();
-
 	}
 	else if (strcmp(map, VOTE_DONTCHANGE, false) == 0)
 	{
@@ -1488,8 +1445,9 @@ public int Handler_MapVoteMenu(Menu menu, MenuAction action, int param1, int par
 			}
 			else if (param1 == VoteCancel_NoVotes && g_Cvar_NoVoteMode.IntValue == 2 && GetClientCount() >= g_Cvar_NoVoteModeMinPlayers.IntValue)
 			{
-				ExtendMapTimeLimit(g_Cvar_ExtendTimeStep.IntValue * 60);
+				ExtendMap();
 				CPrintToChatAll("%s%t", g_szChatPrefix, "No Vote Extend", g_Cvar_ExtendTimeStep.IntValue);
+				LogAction(-1, -1, "Voting for next map has finished. No votes received, so map has been extended.");
 			}
 			else
 			{
@@ -2110,6 +2068,52 @@ stock int AddExtendToMenu(Handle menu, MapChange when)
 	{
 		AddMenuItem(menu, VOTE_EXTEND, "Extend Map");
 	}
+}
+
+stock void ExtendMap()
+{
+	g_Extends++;
+	
+	int time;
+	if (GetMapTimeLimit(time))
+	{
+		if (time > 0)
+		{
+			ExtendMapTimeLimit(g_Cvar_ExtendTimeStep.IntValue * 60);
+		}
+	}
+	
+	if (g_Cvar_Winlimit)
+	{
+		int winlimit = g_Cvar_Winlimit.IntValue;
+		if (winlimit)
+		{
+			g_Cvar_Winlimit.IntValue = winlimit + g_Cvar_ExtendRoundStep.IntValue;
+		}
+	}
+	
+	if (g_Cvar_Maxrounds)
+	{
+		int maxrounds = g_Cvar_Maxrounds.IntValue;
+		if (maxrounds)
+		{
+			g_Cvar_Maxrounds.IntValue = maxrounds + g_Cvar_ExtendRoundStep.IntValue;
+		}
+	}
+	
+	if (g_Cvar_Fraglimit)
+	{
+		int fraglimit = g_Cvar_Fraglimit.IntValue;
+		if (fraglimit)
+		{
+			g_Cvar_Fraglimit.IntValue = fraglimit + g_Cvar_ExtendFragStep.IntValue;
+		}
+	}
+
+	// We extended, so we'll have to vote again.
+	g_HasVoteStarted = false;
+	CreateNextVote();
+	SetupTimeleftTimer();
 }
 
 int GetVoteSize()

--- a/addons/sourcemod/scripting/mapchooser_extended.sp
+++ b/addons/sourcemod/scripting/mapchooser_extended.sp
@@ -1486,7 +1486,7 @@ public int Handler_MapVoteMenu(Menu menu, MenuAction action, int param1, int par
 				SetNextMap(map);
 				g_MapVoteCompleted = true;
 			}
-			else if (param1 == VoteCancel_NoVotes && g_Cvar_NoVoteMode.IntValue == 2 && GetClientCount() > g_Cvar_NoVoteModeMinPlayers.IntValue)
+			else if (param1 == VoteCancel_NoVotes && g_Cvar_NoVoteMode.IntValue == 2 && GetClientCount() >= g_Cvar_NoVoteModeMinPlayers.IntValue)
 			{
 				ExtendMapTimeLimit(g_Cvar_ExtendTimeStep.IntValue * 60);
 				CPrintToChatAll("%s%t", g_szChatPrefix, "No Vote Extend", g_Cvar_ExtendTimeStep.IntValue);

--- a/addons/sourcemod/scripting/mapchooser_extended.sp
+++ b/addons/sourcemod/scripting/mapchooser_extended.sp
@@ -1229,6 +1229,7 @@ public void Handler_VoteFinishedGeneric(Handle menu, int num_votes, int num_clie
 	if (strcmp(map, VOTE_EXTEND, false) == 0)
 	{
 		ExtendMap();
+		CreateNextVote();
 		CPrintToChatAll("%s%t", g_szChatPrefix, "Current Map Extended", RoundToFloor(float(item_info[0][VOTEINFO_ITEM_VOTES])/float(num_votes)*100), num_votes);
 		LogAction(-1, -1, "Voting for next map has finished. The current map has been extended.");
 	}
@@ -1271,7 +1272,7 @@ public void Handler_VoteFinishedGeneric(Handle menu, int num_votes, int num_clie
 	}	
 }
 
-public void Handler_MapVoteFinished(Handle menu, int num_votes, int num_clients, const int[][] client_info, int num_items, const int[][] item_info)
+public int Handler_MapVoteFinished(Handle menu, int num_votes, int num_clients, const int[][] client_info, int num_items, const int[][] item_info)
 {
 	// Implement revote logic - Only run this` block if revotes are enabled and this isn't the last revote
 	if (g_Cvar_RunOff.BoolValue && num_items > 1 && g_RunoffCount < g_Cvar_MaxRunOffs.IntValue)
@@ -2112,7 +2113,6 @@ stock void ExtendMap()
 
 	// We extended, so we'll have to vote again.
 	g_HasVoteStarted = false;
-	CreateNextVote();
 	SetupTimeleftTimer();
 }
 

--- a/addons/sourcemod/scripting/nominations_extended.sp
+++ b/addons/sourcemod/scripting/nominations_extended.sp
@@ -113,6 +113,7 @@ public void OnPluginStart()
 	// Nominations Extended cvars
 	CreateConVar("ne_version", MCE_VERSION, "Nominations Extended Version", FCVAR_SPONLY|FCVAR_NOTIFY|FCVAR_DONTRECORD);
 
+	AutoExecConfig(true, "nominations_extended");
 
 	g_mapTrie = CreateTrie();
 }

--- a/addons/sourcemod/scripting/nominations_extended.sp
+++ b/addons/sourcemod/scripting/nominations_extended.sp
@@ -101,10 +101,10 @@ public void OnPluginStart()
 	g_Cvar_ExcludeOld = CreateConVar("sm_nominate_excludeold", "1", "Specifies if the current map should be excluded from the Nominations list", 0, true, 0.00, true, 1.0);
 	g_Cvar_ExcludeCurrent = CreateConVar("sm_nominate_excludecurrent", "1", "Specifies if the MapChooser excluded maps should also be excluded from Nominations", 0, true, 0.00, true, 1.0);
 	g_Cvar_DisplayName = CreateConVar("sm_nominate_displayname", "1", "Use custom Display Names instead of the raw map name", 0, true, 0.00, true, 1.0);
-	g_Cvar_EnhancedMenu = CreateConVar("smc_enhanced_menu", "1", "Nominate menu can show maps by alphabetic order and tiers", 0, true, 0.0, true, 1.0 );
-	g_Cvar_MinTier = CreateConVar("smc_min_tier", "1", "The minimum tier to show on the enhanced menu",  _, true, 0.0, true, 10.0);
-	g_Cvar_MaxTier = CreateConVar("smc_max_tier", "6", "The maximum tier to show on the enhanced menu",  _, true, 0.0, true, 10.0);
-	g_Cvar_ChatPrefix = CreateConVar("mce_chatprefix", "[SNK.SRV] ", "Chat prefix for all Nominations Extended related messages");
+	g_Cvar_EnhancedMenu = CreateConVar("sm_enhanced_menu", "1", "Nominate menu can show maps by alphabetic order and tiers", 0, true, 0.0, true, 1.0 );
+	g_Cvar_MinTier = CreateConVar("sm_min_tier", "1", "The minimum tier to show on the enhanced menu",  _, true, 0.0, true, 10.0);
+	g_Cvar_MaxTier = CreateConVar("sm_max_tier", "6", "The maximum tier to show on the enhanced menu",  _, true, 0.0, true, 10.0);
+	g_Cvar_ChatPrefix = CreateConVar("sm_nominate_chatprefix", "[SNK.SRV] ", "Chat prefix for all Nominations Extended related messages");
 
 	RegConsoleCmd("sm_nominate", Command_Nominate);
 	

--- a/addons/sourcemod/scripting/rockthevote_extended.sp
+++ b/addons/sourcemod/scripting/rockthevote_extended.sp
@@ -251,7 +251,7 @@ void AttemptRTV(int client)
 	g_Votes++;
 	g_Voted[client] = true;
 
-	CPrintToChatAll("%s%t", "RTV Requested", g_szChatPrefix, name, g_Votes, g_VotesNeeded);
+	CPrintToChatAll("%s%t", g_szChatPrefix, "RTV Requested", name, g_Votes, g_VotesNeeded);
 
 	if (g_Votes >= g_VotesNeeded)
 	{

--- a/addons/sourcemod/translations/mapchooser_extended.phrases.txt
+++ b/addons/sourcemod/translations/mapchooser_extended.phrases.txt
@@ -105,5 +105,11 @@
 		"#format"	"{1:s}"
 		"en"		"*{1}"
 	}
-
+	
+	"No Vote Extend"
+	{
+		"#format"	"{1:i}"
+		"en"		"No votes cast, extending map by {1} minutes."
+	}
+	
 }


### PR DESCRIPTION
This adds the option to extend maps if no votes are received, rather than "do nothing" or "choose a random map".

Creating PR as a draft, because this does not take into account `mce_extend_roundstep` or `mce_extend_fragstep`, and has not yet been tested.